### PR TITLE
Remove unneeded `path.resolve` calls.

### DIFF
--- a/bin/zopflipng
+++ b/bin/zopflipng
@@ -6,7 +6,7 @@ var program = require('commander');
 var fs = require('fs');
 var binary = require('node-pre-gyp');
 var path = require('path');
-var binding_path = binary.find(path.resolve(path.join(__dirname, '../package.json')));
+var binding_path = binary.find(path.join(__dirname, '../package.json'));
 var zopfli = require(binding_path);
 
 program

--- a/lib/zopfli.js
+++ b/lib/zopfli.js
@@ -3,7 +3,7 @@
 var binary = require('node-pre-gyp');
 var path = require('path');
 var defaults = require('defaults');
-var binding_path = binary.find(path.resolve(path.join(__dirname, '../package.json')));
+var binding_path = binary.find(path.join(__dirname, '../package.json'));
 var zopfli = require(binding_path);
 
 var BluebirdPromise = require('bluebird');


### PR DESCRIPTION
```
>> binding_path :  C:\projects\node-zopfli\lib\binding\node-v43-win32-ia32\zopfli.node
>> binding_path2:  C:\projects\node-zopfli\lib\binding\node-v43-win32-ia32\zopfli.node
```