### PR TITLE
Update CI for node v4 and v5.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: cpp
 os:
   - linux
   - osx
-    
+
 # don't re-build for tags so that [publish binary] is not re-run
 # https://github.com/travis-ci/travis-ci/issues/1532
 branches:
@@ -14,6 +14,8 @@ env:
   matrix:
     - NODE_VERSION="0.10"
     - NODE_VERSION="0.12"
+    - NODE_VERSION="4"
+    - NODE_VERSION="5"
     - NODE_VERSION="iojs"
   global:
     - secure: IxORreMUlF3CYU6129/JAQ00ZMR+yxrD8x+nAka8T+qQ8MI3OBkONwYeOXknE0PDgWvD315gPK9KQXSplruEuz8mmxjUJNOzvAikUMF7hVUIl79hSwLDkFZ1MC0rV90dbb7hOlxD1EjqASqTbEJPNarDzIcDxf/G6cubPgnxNbE=

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,50 +1,61 @@
+# http://www.appveyor.com/docs/appveyor-yml
+
+clone_depth: 10
+
+version: "{build}"
+
 environment:
   node_pre_gyp_accessKeyId:
     secure: sNiYns5iJ4x7UzU3Vwt6cwjmSKlJnVYTNPj/wJxtHes=
   node_pre_gyp_secretAccessKey:
     secure: aqsNf2cyJ0hpprZZvwJ3bLeUeFjZ0OhbJSulfs9VLA4rqmADnnbU//aL/NBoXQQJ
   matrix:
-    - nodejs_version: 0.10
-    - nodejs_version: 0.12
-    # - nodejs_version: 1
-
-platform:
-  - x86
-  - x64
+    - nodejs_version: "0.10"
+      platform: x86
+    - nodejs_version: "0.12"
+      platform: x86
+    - nodejs_version: "4"
+      platform: x64
+    - nodejs_version: "4"
+      platform: x86
+    - nodejs_version: "5"
+      platform: x86
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - platform: x86
-      nodejs_version: 1
-    - platform: x64
-      nodejs_version: 1
-
-cache:
-  - '%APPDATA%\npm-cache -> package.json'           # npm cache
-  - 'node_modules -> package.json'                  # local npm modules
 
 install:
-  - ps: Install-Product node $env:nodejs_version $env:platform
-  # get zopfli submodule
+  # Get zopfli submodule
   - git submodule update --init --recursive
-  # add local node-pre-gyp dir to path
+  - ps: Install-Product node $env:nodejs_version $env:platform
+  # Install newer npm for node.js 0.10
+  - ps: >-
+      if ($env:nodejs_version -eq "0.10") {
+        npm install -g npm@3
+        $env:PATH="$env:APPDATA\npm;$env:PATH"
+      }
+  # Add local node-pre-gyp dir to path
   - SET PATH=node_modules\.bin;%PATH%
-  # use 64 bit python if platform is 64 bit
-  - if "%platform%" == "x64" set PATH=C:\Python27-x64;%PATH%
-  - if %platform% == x64 CALL "%VS120COMNTOOLS%..\..\VC\vcvarsall.bat" amd64
-  - if %platform% == x86 CALL "%VS120COMNTOOLS%..\..\VC\vcvarsall.bat" amd64_x86
+  # Use 64-bit Python if platform is 64-bit
+  - IF "%platform%" == "x64" SET "PATH=C:\Python27-x64;%PATH%"
+  - IF "%platform%" == "x64" CALL "%VS140COMNTOOLS%..\..\VC\vcvarsall.bat" amd64
+  - IF "%platform%" == "x86" CALL "%VS140COMNTOOLS%..\..\VC\vcvarsall.bat" x86
   # Print some information
   - node -v
   - npm -v
   # Build
-  - npm install --build-from-source --msvs_version=2013
+  - npm install --build-from-source --msvs_version=2015
   - npm test
   - ps: >-
       if ($env:APPVEYOR_REPO_COMMIT_MESSAGE.ToLower().Contains("[publish binary]")) {
-        cmd /c 'node_modules\.bin\node-pre-gyp --msvs_version=2013 package publish 2>&1'
+        cmd /c 'node_modules\.bin\node-pre-gyp --msvs_version=2015 package publish 2>&1'
       }
 
+cache:
+  - 'node_modules -> package.json'                  # local npm modules
+
 build: off
+
 test: off
+
 deploy: off


### PR DESCRIPTION
@pierreinglebert: this might fail, but we'll get to it eventually :)

Also, do we need both platforms for all node.js versions on Windows? Appveyor is slower than Travis so I enabled build for both on one version (4 which is LTS).