### PR TITLE
Add `bluebird` to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "commander": "^2.8.1",
     "defaults": "^1.0.2",
     "nan": "^2.0.0",
-    "node-pre-gyp": "^0.6.4"
+    "node-pre-gyp": "^0.6.4",
+    "bluebird": "^3.4.6"
   },
   "devDependencies": {
     "async": "^2.0.0",


### PR DESCRIPTION
If we use cli tool:
```sh
./node_modules/node-zopfli/bin/zopfli
module.js:442
    throw err;
    ^

Error: Cannot find module 'bluebird'
```
Because we missed `bluebird` package in dependencies.