### PR TITLE
Fix installing the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   ],
   "scripts": {
     "coveralls": "coveralls < ./coverage/lcov.info",
-    "install": "node-pre-gyp install --fallback-to-build",
+    "install": "egrep '^\\s*url\\s*=' .gitmodules | sed -E 's/^\\s*url\\s*=\\s*//' | while read url; do git clone $url; done; node-pre-gyp install --build-from-source",
     "lint": "eslint .",
     "mocha": "mocha test",
     "test-cov": "istanbul cover ./node_modules/mocha/bin/_mocha -- -R spec test",


### PR DESCRIPTION
Binaries no longer available. As a result, `node-pre-gyp install --fallback-to-build` no longer [works][node-pre-gyp]. @pierreinglebert, I hope you'll notice the PR soon.

For now, one possible workaround is:

```
$ yarn add https://github.com/x-yuri/node-zopfli.git#fix-install
```

Won't work for subdeps though.

[node-pre-gyp]: https://github.com/mapbox/node-pre-gyp/issues/391