### PR TITLE
add ci for node 16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
   matrix:
     - NODE_VERSION="10"
     - NODE_VERSION="12"
+    - NODE_VERSION="16"
 
 matrix:
   fast_finish: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,10 @@ environment:
     nodejs_arch: "x86"
   - nodejs_version: "12"
     nodejs_arch: "x64"
+  - nodejs_version: "16"
+    nodejs_arch: "x86"
+  - nodejs_version: "16"
+    nodejs_arch: "x64"
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
if you like, a few more changes I could add in this PR
- incorporate https://github.com/pierreinglebert/node-zopfli/pull/113
- drop node 10 since it is [no longer supported](https://nodejs.org/en/about/releases/)